### PR TITLE
Enable USB tracing for debugging factory reset process

### DIFF
--- a/factory-reset.py
+++ b/factory-reset.py
@@ -1,6 +1,7 @@
-
 from proto9x.usb import usb
 from proto9x.sensor import factory_reset
 
+usb.enable_trace()
 usb.open()
 factory_reset()
+usb.disable_trace()

--- a/proto9x/usb.py
+++ b/proto9x/usb.py
@@ -1,4 +1,3 @@
-
 import usb.core as ucore
 from binascii import *
 from .util import assert_status, unhex
@@ -15,6 +14,12 @@ class Usb():
         self.trace_enabled = False
         self.queue = Queue(maxsize=10)
         self.quit = None
+
+    def enable_trace(self):
+        self.trace_enabled = True
+
+    def disable_trace(self):
+        self.trace_enabled = False
 
     def purge_int_queue(self):
         try:


### PR DESCRIPTION
Add USB tracing functionality to `proto9x/usb.py` and enable it in `factory-reset.py`.

* **proto9x/usb.py**
  - Add `trace_enabled` attribute to `Usb` class and set it to `False`.
  - Add `enable_trace` method to set `trace_enabled` to `True`.
  - Add `disable_trace` method to set `trace_enabled` to `False`.

* **factory-reset.py**
  - Enable USB tracing by calling `usb.enable_trace()` before `usb.open()`.
  - Disable USB tracing by calling `usb.disable_trace()` after `factory_reset()`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davidecelano/python-validity/pull/5?shareId=15c96d50-1016-4194-a537-7201b0618e71).