### PR TITLE
Enable USB tracing in the project

### DIFF
--- a/proto9x/usb.py
+++ b/proto9x/usb.py
@@ -29,6 +29,7 @@ class Usb():
             pass
 
     def open(self, vendor=0x138a, product=0x0097):
+        self.enable_trace()
         self.dev = ucore.find(idVendor=vendor, idProduct=product)
         self.dev.default_timeout = 15000
         self.thread = Thread(target=lambda: self.int_thread())
@@ -39,6 +40,7 @@ class Usb():
         return self.dev
 
     def send_init(self):
+        self.enable_trace()
         #self.dev.set_configuration()
 
         # TODO analyse responses, detect hardware type


### PR DESCRIPTION
Add calls to `enable_trace` method in `open` and `send_init` methods in `proto9x/usb.py` to enable USB tracing.

* Add `self.enable_trace()` call in the `open` method to set `trace_enabled` to `True`.
* Add `self.enable_trace()` call in the `send_init` method to set `trace_enabled` to `True`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davidecelano/python-validity/pull/6?shareId=dd6f9a68-73dc-4f59-b5e9-4d91e484e89c).